### PR TITLE
匹配最新的2021年11月2日之后，东北大学升级后的网关登陆脚本。

### DIFF
--- a/NEUNetworkConnect.py
+++ b/NEUNetworkConnect.py
@@ -1,32 +1,45 @@
-# -*- coding:utf-8 -*-
 import re
 import requests
-
-# 给一些基本变量赋值
-url="https://ipgw.neu.edu.cn/srun_cas.php?ac_id=1"
+url="https://pass.neu.edu.cn/tpass/login?service=http%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_portal_sso%3Fac_id%3D1"
 head={
     "User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0",
-    "Connection":"close"
+    "Connection":"close",
+    "Host": "pass.neu.edu.cn",
+	"Referer": "https://pass.neu.edu.cn/tpass/login?service=http%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_portal_sso%3Fac_id%3D1",
+    "Origin": "https://pass.neu.edu.cn",
+    "Upgrade-Insecure-Requests": "1"
 }
 sess=requests.session()
 req=sess.get(url,headers=head)
+
+cookie = req.cookies
 lt_execution_id=re.findall('name="lt" value="(.*?)".*\sname="execution" value="(.*?)"', req.text, re.S)
 
-# 设置账号密码
 payload={
-    "rsa":"学号密码"+lt_execution_id[0][0],
-    "ul":"学号长度",
-    "pl":"密码长度",
+    "rsa":"2188888goodjob8888"+lt_execution_id[0][0],
+    "ul":"7",
+    "pl":"11",
     "lt":lt_execution_id[0][0],
     "execution":lt_execution_id[0][1],
     "_eventId":"submit"
 }
+r2=sess.post("https://pass.neu.edu.cn/tpass/login?service=http%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_portal_sso%3Fac_id%3D1", headers=head, data=payload, 
+             cookies=cookie, allow_redirects=False, verify=False)
 
-# 发送请求
-r2=sess.post("https://pass.neu.edu.cn/tpass/login?service=https%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_cas.php%3Fac_id%3D1",headers=head,data=payload)
+Location = r2.headers['Location']
+r2=sess.get(Location.replace('http://ipgw.neu.edu.cn/','http://ipgw.neu.edu.cn/v1/'),headers=head,cookies=cookie)
 
-# 打印结果
-print(r2.text)
-"""
-东北大学校园网联网代码
-"""
+#---unnecessary----
+# import numpy as np
+# import time
+# def produce_jQuery():
+#     global jQuery
+#     strnum = ""
+#     for i in range(21):
+#         strnum = strnum+str(int(np.random.uniform(0, 9)))
+#     jQuery = "jQuery"+strnum+"_"
+
+# produce_jQuery()
+# callback = jQuery+str(int(time.time()*1000))
+
+# r2=sess.get('http://ipgw.neu.edu.cn/cgi-bin/rad_user_info?callback='+callback,headers=head, cookies=cookie)

--- a/NEUNetworkConnect_chrome.py
+++ b/NEUNetworkConnect_chrome.py
@@ -1,0 +1,28 @@
+from selenium import webdriver
+
+chrome_options = webdriver.ChromeOptions()
+chrome_options.add_argument('--headless')
+chrome_options.add_argument('--no-sandbox')
+
+url = r"https://pass.neu.edu.cn/tpass/login?service=http%3A%2F%2Fipgw.neu.edu.cn%2Fsrun_portal_sso%3Fac_id%3D1"
+# 用户名密码
+stu_number = '2188888'
+stu_pass = 'goodjob8888'
+
+driver = webdriver.Chrome(chrome_options=chrome_options)
+driver.get(url)
+
+elem = driver.find_element_by_name('un')
+elem.send_keys(stu_number)
+
+elem = driver.find_element_by_name('pd')
+elem.send_keys(stu_pass)
+
+driver.find_element('id', 'index_login_btn').click()
+
+driver.quit()
+
+
+"""
+东北大学校园网联网代码
+"""

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 
 1、找到并修改此处的代码
 
-例如：学号：123456，密码：abcdefg
+例如：学号：2188888，密码：goodjob8888
 
 payload={
 
-    "rsa":"123456abcdefg"+lt_execution_id[0][0],
+    "rsa":"2188888goodjob8888"+lt_execution_id[0][0],
     
-    "ul":"6",
+    "ul":"7",
     
-    "pl":"7",
+    "pl":"11",
     
     "lt":lt_execution_id[0][0],
     
@@ -26,3 +26,51 @@ payload={
 2、在控制台输入指令
 
 python /你的脚本文件存放目录/NEUNetworkConnect.py
+
+***
+**最新版本补充说明：匹配最新的2021年11月2日之后，东北大学升级后的网关登陆脚本。**
+
+升级后的网关登陆方式由原来的账号登陆（pc）改为了CAS登陆（sso），因此增加了一步跳转，增加了sever ticket认证。
+这里相应匹配了自动获取ticket，并保存登陆cookie。
+
+另外附送了一个利用chromedrive and selenium 进行模拟浏览器登陆的脚本。脚本利用chrome的headless模式可以实现linux自动登陆。
+
+相关参考教程：
+1. sso登陆：https://www.jianshu.com/p/8cd6e9bc2680
+2. linux环境下chromedrive headless 设置：https://blog.csdn.net/qq_41963758/article/details/80320309
+3. linux下使用selenium（环境部署）：https://www.jianshu.com/p/cbc01d32c7b0/
+4. ubuntu（64位）三行命令安装chrome浏览器：https://www.cnblogs.com/Rainingday/p/12426010.html
+
+新闻链接：
+1. http://xwb.neu.edu.cn/2021/1029/c5728a205587/page.htm
+
+chrome登陆分析：
+[![IAVQns.png](https://z3.ax1x.com/2021/11/03/IAVQns.png)](https://imgtu.com/i/IAVQns)
+[![IAVN3F.png](https://z3.ax1x.com/2021/11/03/IAVN3F.png)](https://imgtu.com/i/IAVN3F)
+
+***
+*另附：ubuntu自启动教程*
+例如：
+python路径：`/home/root/miniconda3/bin/python`
+自动登陆脚本路径：`/home/root/NEUNetworkConnect.py`
+在/etc/rc.local脚本中添加
+
+```
+#!/bin/sh -e
+
+/home/root/miniconda3/bin/python /home/root/NEUNetworkConnect.py
+
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+exit 0
+```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ payload={
 
     "rsa":"2188888goodjob8888"+lt_execution_id[0][0],
     
-    "ul":"7",
+    "ul":"7", #学号长度
     
-    "pl":"11",
+    "pl":"11", #密码长度
     
     "lt":lt_execution_id[0][0],
     

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ chrome登陆分析：
 [![IAVN3F.png](https://z3.ax1x.com/2021/11/03/IAVN3F.png)](https://imgtu.com/i/IAVN3F)
 
 ***
-*另附：ubuntu自启动教程*
-例如：
+*另附：ubuntu自启动教程，例如：*
+
 python路径：`/home/root/miniconda3/bin/python`
+
 自动登陆脚本路径：`/home/root/NEUNetworkConnect.py`
+
 在/etc/rc.local脚本中添加
 
 ```


### PR DESCRIPTION
升级后的网关登陆方式由原来的账号登陆（pc）改为了CAS登陆（sso），因此增加了一步跳转，增加了sever ticket认证。
这里相应匹配了自动获取ticket，并保存登陆cookie。

另外附送了一个利用chromedrive and selenium 进行模拟浏览器登陆的脚本。脚本利用chrome的headless模式可以实现linux自动登陆。

相关参考教程：
1. sso登陆：https://www.jianshu.com/p/8cd6e9bc2680
2. linux环境下chromedrive headless 设置：https://blog.csdn.net/qq_41963758/article/details/80320309
3. linux下使用selenium（环境部署）：https://www.jianshu.com/p/cbc01d32c7b0/
4. ubuntu（64位）三行命令安装chrome浏览器：https://www.cnblogs.com/Rainingday/p/12426010.html

新闻链接：
1. http://xwb.neu.edu.cn/2021/1029/c5728a205587/page.htm